### PR TITLE
Feat/add ci trivy

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -52,6 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+          IGNORE_UNFIXED: 'false'
   trivy-fs:
     name: Filesystem scan
     runs-on: gha-runners-smartweb
@@ -65,6 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+          IGNORE_UNFIXED: 'false'
   deploy:
     runs-on: gha-runners-smartweb
     needs: trivy-image

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -12,6 +12,7 @@ env:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   build-push:
@@ -35,9 +36,25 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
-  deploy:
+  trivy-image:
+    name: Image scan
     runs-on: gha-runners-smartweb
     needs: build-push
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:staging
+          EXIT_CODE: '0'
+          TRIVYIGNORES: ''
+          TRIVY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
+          TRIVY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'true'
+  deploy:
+    runs-on: gha-runners-smartweb
+    needs: trivy-image
     steps:
       - name: Deploy to dev and notify
         uses: IMIO/gha/rundeck-notify@v6

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -69,7 +69,7 @@ jobs:
           IGNORE_UNFIXED: 'false'
   deploy:
     runs-on: gha-runners-smartweb
-    needs: trivy-image
+    needs: [trivy-image, trivy-fs]
     steps:
       - name: Deploy to dev and notify
         uses: IMIO/gha/rundeck-notify@v7

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,7 +28,7 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
       - name: Build push and notify
-        uses: IMIO/gha/build-push-notify@v6
+        uses: IMIO/gha/build-push-notify@v7
         with:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
@@ -41,7 +41,7 @@ jobs:
     runs-on: gha-runners-smartweb
     needs: build-push
     steps:
-      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+      - uses: IMIO/gha/trivy-scan-notify@v7
         with:
           SCAN_TYPE: image
           IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:staging
@@ -52,12 +52,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+  trivy-fs:
+    name: Filesystem scan
+    runs-on: gha-runners-smartweb
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: fs
+          SCAN_REF: .
+          EXIT_CODE: '0'
+          TRIVYIGNORES: ''
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'true'
   deploy:
     runs-on: gha-runners-smartweb
     needs: trivy-image
     steps:
       - name: Deploy to dev and notify
-        uses: IMIO/gha/rundeck-notify@v6
+        uses: IMIO/gha/rundeck-notify@v7
         with:
           RUNDECK_URL: ${{ secrets.RUNDECK_URL }}
           RUNDECK_TOKEN: ${{ secrets.SMARTWEB_RUNDECK_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: IMIO/gha/trivy-scan-notify@v7
         with:
           SCAN_TYPE: image
-          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:staging
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:dev
           EXIT_CODE: '0'
           TRIVYIGNORES: ''
           TRIVY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feat/add-ci-trivy
     tags:
       - '!**'
   workflow_dispatch:
@@ -29,7 +28,7 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
       - name: Build push and notify
-        uses: IMIO/gha/build-push-notify@v6
+        uses: IMIO/gha/build-push-notify@v7
         with:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
@@ -42,7 +41,7 @@ jobs:
     runs-on: gha-runners-smartweb
     needs: build-push
     steps:
-      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+      - uses: IMIO/gha/trivy-scan-notify@v7
         with:
           SCAN_TYPE: image
           IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:staging
@@ -53,12 +52,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+  trivy-fs:
+    name: Filesystem scan
+    runs-on: gha-runners-smartweb
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: fs
+          SCAN_REF: .
+          EXIT_CODE: '0'
+          TRIVYIGNORES: ''
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'true'
   deploy:
     runs-on: gha-runners-smartweb
     needs: trivy-image
     steps:
       - name: Deploy to staging and notify
-        uses: IMIO/gha/rundeck-notify@v6
+        uses: IMIO/gha/rundeck-notify@v7
         with:
           RUNDECK_URL: ${{ secrets.RUNDECK_URL }}
           RUNDECK_TOKEN: ${{ secrets.SMARTWEB_RUNDECK_TOKEN }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -52,6 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+          IGNORE_UNFIXED: 'false'
   trivy-fs:
     name: Filesystem scan
     runs-on: gha-runners-smartweb
@@ -65,6 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+          IGNORE_UNFIXED: 'false'
   deploy:
     runs-on: gha-runners-smartweb
     needs: trivy-image

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,6 +5,7 @@ on:
       - main
     tags:
       - '!**'
+  workflow_dispatch:
 env:
   IMAGE_NAME: 'web/smartweb/mutual'
   REGISTRY_URL: ${{ secrets.HARBOR_URL }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feat/add-ci-trivy
     tags:
       - '!**'
   workflow_dispatch:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -69,7 +69,7 @@ jobs:
           IGNORE_UNFIXED: 'false'
   deploy:
     runs-on: gha-runners-smartweb
-    needs: trivy-image
+    needs: [trivy-image, trivy-fs]
     steps:
       - name: Deploy to staging and notify
         uses: IMIO/gha/rundeck-notify@v7

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,7 @@ env:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   build-push:
@@ -36,18 +37,6 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
-  deploy:
-    runs-on: gha-runners-smartweb
-    needs: build-push
-    steps:
-      - name: Deploy to staging and notify
-        uses: IMIO/gha/rundeck-notify@v6
-        with:
-          RUNDECK_URL: ${{ secrets.RUNDECK_URL }}
-          RUNDECK_TOKEN: ${{ secrets.SMARTWEB_RUNDECK_TOKEN }}
-          RUNDECK_JOB_ID: ${{ secrets.RUNDECK_DEPLOY_STAGING_JOB_ID }}
-          RUNDECK_PARAMETERS: '-X POST'
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
   trivy-image:
     name: Image scan
     runs-on: gha-runners-smartweb
@@ -63,4 +52,16 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
-          UPLOAD_SARIF: 'false'
+          UPLOAD_SARIF: 'true'
+  deploy:
+    runs-on: gha-runners-smartweb
+    needs: trivy-image
+    steps:
+      - name: Deploy to staging and notify
+        uses: IMIO/gha/rundeck-notify@v6
+        with:
+          RUNDECK_URL: ${{ secrets.RUNDECK_URL }}
+          RUNDECK_TOKEN: ${{ secrets.SMARTWEB_RUNDECK_TOKEN }}
+          RUNDECK_JOB_ID: ${{ secrets.RUNDECK_DEPLOY_STAGING_JOB_ID }}
+          RUNDECK_PARAMETERS: '-X POST'
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -47,3 +47,18 @@ jobs:
           RUNDECK_JOB_ID: ${{ secrets.RUNDECK_DEPLOY_STAGING_JOB_ID }}
           RUNDECK_PARAMETERS: '-X POST'
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+  trivy-image:
+    name: Image scan
+    runs-on: gha-runners-smartweb
+    needs: build-push
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:staging
+          EXIT_CODE: '0'
+          TRIVY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
+          TRIVY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'false'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -58,6 +58,7 @@ jobs:
           SCAN_TYPE: image
           IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:staging
           EXIT_CODE: '0'
+          TRIVYIGNORES: ''
           TRIVY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
           TRIVY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: IMIO/gha/trivy-scan-notify@v7
         with:
           SCAN_TYPE: image
-          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:trivy
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:trivy-${{ github.run_number }}
           EXIT_CODE: '0'
           TRIVYIGNORES: ''
           TRIVY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,8 +31,8 @@ jobs:
         run: |
           {
             echo 'IMAGE_TAGS<<EOF'
-            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:trivy-cron-'
-            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:trivy-cron-${{ github.run_number }}'
+            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:trivy'
+            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:trivy-${{ github.run_number }}'
             echo EOF
           } >> $GITHUB_ENV
       - name: Build push and notify
@@ -52,7 +52,7 @@ jobs:
       - uses: IMIO/gha/trivy-scan-notify@v7
         with:
           SCAN_TYPE: image
-          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:trivy-cron
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:trivy
           EXIT_CODE: '0'
           TRIVYIGNORES: ''
           TRIVY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,6 +24,7 @@ jobs:
           SCAN_TYPE: fs
           SCAN_REF: .
           EXIT_CODE: '0'
+          TRIVYIGNORES: ''
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'false'
@@ -37,6 +38,7 @@ jobs:
           SCAN_TYPE: config
           SCAN_REF: .
           EXIT_CODE: '0'
+          TRIVYIGNORES: ''
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'false'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+          IGNORE_UNFIXED: 'false'
   build-push:
     runs-on: gha-runners-smartweb
     steps:
@@ -62,3 +63,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
+          IGNORE_UNFIXED: 'false'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - feat/add-ci-trivy
   pull_request:
   schedule:
     - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   trivy-fs:
@@ -27,7 +28,7 @@ jobs:
           TRIVYIGNORES: ''
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
-          UPLOAD_SARIF: 'false'
+          UPLOAD_SARIF: 'true'
 
   trivy-iac:
     name: IaC / config scan
@@ -41,4 +42,4 @@ jobs:
           TRIVYIGNORES: ''
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
-          UPLOAD_SARIF: 'false'
+          UPLOAD_SARIF: 'true'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,11 +2,6 @@ name: Trivy security scan
 
 on:
   push:
-    branches:
-      - main
-      - dev
-      - feat/add-ci-trivy
-  pull_request:
   schedule:
     - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC
   workflow_dispatch:
@@ -20,7 +15,7 @@ jobs:
     name: Filesystem scan
     runs-on: gha-runners-smartweb
     steps:
-      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+      - uses: IMIO/gha/trivy-scan-notify@v7
         with:
           SCAN_TYPE: fs
           SCAN_REF: .
@@ -29,17 +24,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'
-
-  trivy-iac:
-    name: IaC / config scan
+  build-push:
     runs-on: gha-runners-smartweb
     steps:
-      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+      - name: Build tags
+        run: |
+          {
+            echo 'IMAGE_TAGS<<EOF'
+            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:trivy-cron-'
+            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:trivy-cron-${{ github.run_number }}'
+            echo EOF
+          } >> $GITHUB_ENV
+      - name: Build push and notify
+        uses: IMIO/gha/build-push-notify@v7
         with:
-          SCAN_TYPE: config
-          SCAN_REF: .
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
+          REGISTRY_URL: ${{ env.REGISTRY_URL}}
+          REGISTRY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+  trivy-image:
+    name: Image scan
+    runs-on: gha-runners-smartweb
+    needs: build-push
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@v7
+        with:
+          SCAN_TYPE: image
+          IMAGE_REF: ${{ secrets.HARBOR_URL }}/web/smartweb/mutual:trivy-cron
           EXIT_CODE: '0'
           TRIVYIGNORES: ''
+          TRIVY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
+          TRIVY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
           UPLOAD_SARIF: 'true'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,7 +1,6 @@
 name: Trivy security scan
 
 on:
-  push:
   schedule:
     - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC
   workflow_dispatch:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,41 @@
+name: Trivy security scan
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+  schedule:
+    - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-fs:
+    name: Filesystem scan
+    runs-on: gha-runners-smartweb
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+        with:
+          SCAN_TYPE: fs
+          SCAN_REF: .
+          EXIT_CODE: '0'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'false'
+
+  trivy-iac:
+    name: IaC / config scan
+    runs-on: gha-runners-smartweb
+    steps:
+      - uses: IMIO/gha/trivy-scan-notify@feat/trivy
+        with:
+          SCAN_TYPE: config
+          SCAN_REF: .
+          EXIT_CODE: '0'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+          UPLOAD_SARIF: 'false'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 4 * * 1'  # Every Monday at 04:00 UTC
   workflow_dispatch:
+env:
+  IMAGE_NAME: 'web/smartweb/mutual'
+  REGISTRY_URL: ${{ secrets.HARBOR_URL }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Enable trivy scans with github actions.
currently, EXIT_CODE is set to 0 (to only report), so it doesn't fail. We can enable it when vulnerabilities are fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated security scans for container images and repository files (dev, staging).
  * Scheduled weekly scans plus manual on‑demand runs.
  * Deployments now wait for scans to complete; scan findings are reported without blocking releases.
  * Scan results are uploaded for security reporting and notifications.

* **Chores**
  * CI actions bumped to newer versions.
  * CI workflow permissions expanded to support security reporting and SARIF uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->