### PR TITLE
feat: script to remove accumulated debug JSONS annotations from conta…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 1.5.33 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-4414 : Add ``scripts/clean_jsons_annotations.py`` to remove accumulated debug JSONS annotations from contact/events/news/publications sections.
+  [remdub]
 
 
 1.5.32 (2026-04-28)

--- a/scripts/clean_jsons_annotations.py
+++ b/scripts/clean_jsons_annotations.py
@@ -1,0 +1,36 @@
+from zope.annotation.interfaces import IAnnotations
+import transaction
+
+SECTION_TYPES = [
+    "imio.smartweb.SectionContact",
+    "imio.smartweb.SectionEvents",
+    "imio.smartweb.SectionNews",
+    "imio.smartweb.SectionTimestampedPublications",
+]
+
+brains = app.Plone.portal_catalog(portal_type=SECTION_TYPES)
+total_brains = len(brains)
+cleaned = []
+
+for i, brain in enumerate(brains, 1):
+    obj = brain.getObject()
+    ann = IAnnotations(obj)
+    if "JSONS" in ann:
+        entries = len(ann["JSONS"])
+        size_kb = sum(len(str(item)) for item in ann["JSONS"]) // 1024
+        del ann["JSONS"]
+        cleaned.append((brain.getPath(), entries, size_kb))
+        print(f"[{i}/{total_brains}] REMOVED   {brain.getPath()} — {entries} entries, ~{size_kb} KB")
+    else:
+        print(f"[{i}/{total_brains}] ok        {brain.getPath()}")
+
+transaction.commit()
+
+print("\n=== Summary ===")
+print(f"Sections scanned       : {total_brains}")
+print(f"Annotations removed    : {len(cleaned)}")
+print(f"Total space freed      : ~{sum(s for _, _, s in cleaned)} KB")
+if cleaned:
+    print("\nDetails:")
+    for path, entries, size_kb in cleaned:
+        print(f"  {path} ({entries} entries, ~{size_kb} KB)")

--- a/scripts/clean_jsons_annotations.py
+++ b/scripts/clean_jsons_annotations.py
@@ -17,6 +17,8 @@ SECTION_TYPES = [
     "imio.smartweb.SectionTimestampedPublications",
 ]
 
+BATCH_SIZE = 100
+
 brains = app.Plone.portal_catalog(portal_type=SECTION_TYPES)
 total_brains = len(brains)
 cleaned = []
@@ -32,6 +34,9 @@ for i, brain in enumerate(brains, 1):
         logger.info(f"[{i}/{total_brains}] REMOVED   {brain.getPath()} — {entries} entries, ~{size_kb} KB")
     else:
         logger.info(f"[{i}/{total_brains}] ok        {brain.getPath()}")
+    if i % BATCH_SIZE == 0:
+        transaction.commit()
+        logger.info(f"Intermediate commit after {i} sections")
 
 transaction.commit()
 

--- a/scripts/clean_jsons_annotations.py
+++ b/scripts/clean_jsons_annotations.py
@@ -1,5 +1,14 @@
-from zope.annotation.interfaces import IAnnotations
+import logging
+import sys
 import transaction
+from zope.annotation.interfaces import IAnnotations
+
+logger = logging.getLogger("clean_jsons_annotations")
+logger.setLevel(logging.INFO)
+logger.propagate = False
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+logger.addHandler(handler)
 
 SECTION_TYPES = [
     "imio.smartweb.SectionContact",
@@ -20,17 +29,15 @@ for i, brain in enumerate(brains, 1):
         size_kb = sum(len(str(item)) for item in ann["JSONS"]) // 1024
         del ann["JSONS"]
         cleaned.append((brain.getPath(), entries, size_kb))
-        print(f"[{i}/{total_brains}] REMOVED   {brain.getPath()} — {entries} entries, ~{size_kb} KB")
+        logger.info(f"[{i}/{total_brains}] REMOVED   {brain.getPath()} — {entries} entries, ~{size_kb} KB")
     else:
-        print(f"[{i}/{total_brains}] ok        {brain.getPath()}")
+        logger.info(f"[{i}/{total_brains}] ok        {brain.getPath()}")
 
 transaction.commit()
 
-print("\n=== Summary ===")
-print(f"Sections scanned       : {total_brains}")
-print(f"Annotations removed    : {len(cleaned)}")
-print(f"Total space freed      : ~{sum(s for _, _, s in cleaned)} KB")
-if cleaned:
-    print("\nDetails:")
-    for path, entries, size_kb in cleaned:
-        print(f"  {path} ({entries} entries, ~{size_kb} KB)")
+logger.info("=== Summary ===")
+logger.info(f"Sections scanned       : {total_brains}")
+logger.info(f"Annotations removed    : {len(cleaned)}")
+logger.info(f"Total space freed      : ~{sum(s for _, _, s in cleaned)} KB")
+for path, entries, size_kb in cleaned:
+    logger.info(f"  {path} ({entries} entries, ~{size_kb} KB)")


### PR DESCRIPTION
…ct/events/news/publications sections

WEB-4414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cleanup utility that scans contact, events, news, and publications sections to find and remove accumulated debug annotations, reporting per-section results, batch progress, and approximate storage reclaimed.

* **Documentation**
  * Release notes updated to document the new cleanup utility and its reported outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->